### PR TITLE
07 投稿の検索機能を実装する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,6 @@ class ApplicationController < ActionController::Base
   end
 
   def search_post_params
-    params.fetch(:q, {}).permit(:body)
+    params.fetch(:q, {}).permit(:body, :comment_body, :username)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,11 +11,17 @@ class ApplicationController < ActionController::Base
   end
 
   # ヘッダー部分(=共通部分)に検索フォームを置くので、ApplicationControllerに実装
+  # 検索ワードをインスタンス変数に代入
   def set_search_posts_form
     @search_form = SearchPostsForm.new(search_post_params)
+    # [3] pry(#<PostsController>)> search_post_params
+    # => <ActionController::Parameters {"body"=>"it", "comment_body"=>"", "username"=>""} permitted: true>
   end
 
   def search_post_params
+    # paramsはフォームなどによって送られてきた情報（パラメータ）を取得する
+    # fetchメソッドはハッシュから指定したキーのバリュ−を取り出す。
+    # params.fetch(:q, {})は、params[:q]が空の場合はnil({})を返し、あればparams[:q]を返す
     params.fetch(:q, {}).permit(:body, :comment_body, :username)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,20 @@ class ApplicationController < ActionController::Base
   # フラッシュメッセージのキーを許可する記述
   # これでBootstrapに対応した success info warning danger 4つのキーが使用できる
   add_flash_types :success, :info, :warning, :danger
+  before_action :set_search_posts_form
+
+  private
 
   def not_authenticated
     redirect_to login_path, warning: 'ログインしてください'
+  end
+
+  # ヘッダー部分(=共通部分)に検索フォームを置くので、ApplicationControllerに実装
+  def set_search_posts_form
+    @search_form = SearchPostsForm.new(search_post_params)
+  end
+
+  def search_post_params
+    params.fetch(:q, {}).permit(:body)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -79,6 +79,10 @@ class PostsController < ApplicationController
     redirect_to posts_path, success: '投稿を削除しました'
   end
 
+  def search
+    @posts = @search_form.search.includes(:user).page(params[:page])
+  end
+
   private
 
   def post_params

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -79,6 +79,8 @@ class PostsController < ApplicationController
     redirect_to posts_path, success: '投稿を削除しました'
   end
 
+  # 検索結果を表示させるアクション
+  # メソッド内のsearchはモデルのスコープ
   def search
     @posts = @search_form.search.includes(:user).page(params[:page])
   end

--- a/app/forms/search_posts_form.rb
+++ b/app/forms/search_posts_form.rb
@@ -9,7 +9,7 @@ class SearchPostsForm
   def search
     scope = Post.distinct
     scope = splited_bodies.map { |splited_body| scope.body_contain(splited_body)}.inject{ |result, scp| result.or(scp) } if body.present?
-    scope = scope.comment_body_contain(body) if comment_body.present?
+    scope = scope.comment_body_contain(comment_body) if comment_body.present?
     scope = scope.username_contain(username) if username.present?
     scope
   end

--- a/app/forms/search_posts_form.rb
+++ b/app/forms/search_posts_form.rb
@@ -1,0 +1,13 @@
+class SearchPostsForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :body, :string
+  attribute :comment_body, :string
+
+  def search
+    scope = Post.distinct
+    scope = scope.body_contain(body) if body.present?
+    scope
+  end
+end

--- a/app/forms/search_posts_form.rb
+++ b/app/forms/search_posts_form.rb
@@ -1,14 +1,35 @@
 class SearchPostsForm
+  # includeすることにより、ActiveModel::ModelとActiveModel::Attributesが使える
+  # includeしているものは「モジュール」という
+  # これにより、モデルっぽいものが作れる
   include ActiveModel::Model
   include ActiveModel::Attributes
 
+  # ActiveRecord(モデル)のカラムのような属性を加えられる
   attribute :body, :string
   attribute :comment_body, :string
   attribute :username, :string
 
   def search
     scope = Post.distinct
-    scope = splited_bodies.map { |splited_body| scope.body_contain(splited_body)}.inject{ |result, scp| result.or(scp) } if body.present?
+    # mapはブロック内の処理をした結果を配列として返す
+    # splited_bodies.map｛ |splited_body| scope.body_contain(splited_body) }
+    #  ↓
+    # ["電車", "卵", "携帯"].map ｛ |splited_body| scope.body_contain(splited_body) }
+    #  ↓
+    # [scope.body_contain("電車"), scope.body_contain("卵"), scope.body_contain("携帯")]
+    #  ↓
+    # これがActiveRecord::Relationの形になっている(配列と形は同じだが、厳密には配列ではない)。例えば、[[a, b, c], [d, e], [f]]。
+    #  ↓
+    # splited_bodies.map { |splited_body| scope.body_contain(splited_body) }.inject { |result, scp| result.or(scp) }
+    #  ↓
+    # [scope.body_contain("電車"), scope.body_contain("卵"), scope.body_contain("携帯")].inject { |result, scp| result.or(scp) }
+    #  ↓
+    # scope.body_contain("電車").or(scope.body_contain("卵")).or.(scope.body_contain("携帯"))
+    #  ↓
+    # injectメソッドで[a ,b, c, d, e, f]の形にする。
+    scope = splited_bodies.map { |splited_body| scope.body_contain(splited_body) }.inject { |result, scp| result.or(scp) } if body.present?
+    # if comment_body.present?には、self(@search_form)がSearchPostsFormのインスタンスなので省略されている
     scope = scope.comment_body_contain(comment_body) if comment_body.present?
     scope = scope.username_contain(username) if username.present?
     scope
@@ -17,6 +38,8 @@ class SearchPostsForm
   private
 
   def splited_bodies
+    # " abc def ghi "はsplitメソッドで"abc def ghi"となり、文字列先頭と最後の空白を削除
+    # (/[[:blank]]+/)は、空白が1回以上のところで文字列を分割し配列で返す
     body.strip.split(/[[:blank]]+/)
   end
 end

--- a/app/forms/search_posts_form.rb
+++ b/app/forms/search_posts_form.rb
@@ -4,10 +4,19 @@ class SearchPostsForm
 
   attribute :body, :string
   attribute :comment_body, :string
+  attribute :username, :string
 
   def search
     scope = Post.distinct
-    scope = scope.body_contain(body) if body.present?
+    scope = splited_bodies.map { |splited_body| scope.body_contain(splited_body)}.inject{ |result, scp| result.or(scp) } if body.present?
+    scope = scope.comment_body_contain(body) if comment_body.present?
+    scope = scope.username_contain(username) if username.present?
     scope
+  end
+
+  private
+
+  def splited_bodies
+    body.strip.split(/[[:blank]]+/)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -30,4 +30,5 @@ class Post < ApplicationRecord
   has_many :likes, dependent: :destroy
   # postにいいねしたユーザーを直接アソシエーションで取得することができる
   has_many :like_users, through: :likes, source: :user
+  scope :body_contain, ->(word) { where('body LIKE ?', "%#{word}%" )}
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -31,4 +31,6 @@ class Post < ApplicationRecord
   # postにいいねしたユーザーを直接アソシエーションで取得することができる
   has_many :like_users, through: :likes, source: :user
   scope :body_contain, ->(word) { where('body LIKE ?', "%#{word}%" )}
+  scope :comment_body_contain, ->(word) { joins(:comments).where('comments.body LIKE ?', "%#{word}%") }
+  scope :username_contain, ->(word) { joins(:user).where('username LIKE ?', "%#{word}%") }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -30,7 +30,7 @@ class Post < ApplicationRecord
   has_many :likes, dependent: :destroy
   # postにいいねしたユーザーを直接アソシエーションで取得することができる
   has_many :like_users, through: :likes, source: :user
-  scope :body_contain, ->(word) { where('body LIKE ?', "%#{word}%" )}
+  scope :body_contain, ->(word) { where('posts.body LIKE ?', "%#{word}%" )}
   scope :comment_body_contain, ->(word) { joins(:comments).where('comments.body LIKE ?', "%#{word}%") }
   scope :username_contain, ->(word) { joins(:user).where('username LIKE ?', "%#{word}%") }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -30,6 +30,8 @@ class Post < ApplicationRecord
   has_many :likes, dependent: :destroy
   # postにいいねしたユーザーを直接アソシエーションで取得することができる
   has_many :like_users, through: :likes, source: :user
+  # where("カラム名 LIKE ?", "検索したい文字列")であり、?はプレースホルダと呼ばれ､第二引数で指定した値が置き換えられる。
+  # SQLインジェクション対策である。
   scope :body_contain, ->(word) { where('posts.body LIKE ?', "%#{word}%" )}
   scope :comment_body_contain, ->(word) { joins(:comments).where('comments.body LIKE ?', "%#{word}%") }
   scope :username_contain, ->(word) { joins(:user).where('username LIKE ?', "%#{word}%") }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,8 +27,14 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
   # foreign_keyで定義することで、親モデル(follower)と関連付けられる。
+  # foreign_keyでフォローする側(follower)からフォロー関係を関連付けている。
+  # この段階では、自分が誰をフォローしているかまでしかわからない(active_relationshipsテーブルのレコードを取得しているにすぎない)。
   has_many :active_relationships, class_name: 'Relationship', foreign_key: 'follower_id', dependent: :destroy
+  # これでようやくフォローされる側(followed)のユーザーを中間テーブル(active_relationships)を介して取得することを「following」と定義
+  has_many :following, through: :active_relationships, source: :followed
   # foreign_keyで定義することで、親モデル(followed)と関連付けられる。
+  # フォローされる側(followed)からフォロー関係を関連付けている。
+  # この段階では、自分が誰からフォローされているかまでしかわからない(passive_relationshipsテーブルのレコードを取得しているにすぎない)。
   has_many :passive_relationships, class_name: 'Relationship', foreign_key: 'followed_id', dependent: :destroy
   # フォローされる側(followed)のユーザーを中間テーブル(active_relationships)を介して取得することを「following」と定義
   has_many :following, through: :active_relationships, source: :followed

--- a/app/views/posts/_search_form.html.slim
+++ b/app/views/posts/_search_form.html.slim
@@ -1,0 +1,3 @@
+= form_with model: search_form, url: search_posts_path, scope: :q, class: 'form-inline my-2 my-lg-0 mr-auto', method: :get, local: true do |f|
+  = f.search_field :body, class: 'form-control mr-sm-2', placeholder: '本文'
+  = f.submit 'Search', class: 'btn btn-outline-success my-2 my-sm-0'

--- a/app/views/posts/_search_form.html.slim
+++ b/app/views/posts/_search_form.html.slim
@@ -1,3 +1,5 @@
 = form_with model: search_form, url: search_posts_path, scope: :q, class: 'form-inline my-2 my-lg-0 mr-auto', method: :get, local: true do |f|
   = f.search_field :body, class: 'form-control mr-sm-2', placeholder: '本文'
+  = f.search_field :comment_body, class: 'form-control mr-sm-2', placeholder: 'コメント'
+  = f.search_field :username, class: 'form-control mr-sm-2', placeholder: 'ユーザー名'
   = f.submit 'Search', class: 'btn btn-outline-success my-2 my-sm-0'

--- a/app/views/posts/_search_form.html.slim
+++ b/app/views/posts/_search_form.html.slim
@@ -1,3 +1,8 @@
+/ modelオプションは、モデルクラスのインスタンスを指定する
+/ urlオプションは、指定したpathに対してGETメソッドやPOSTメソッドを行う
+/ scopeオプションは、scopeオブジェクトに渡した値がname値のプレフィックスになっている
+/ q[:body], q[:comment_body], q[:username]
+/ 検索ワードを入力したら、@search_form = q[:body]をsearch_posts_pathに対してGETメソッドを行う
 = form_with model: search_form, url: search_posts_path, scope: :q, class: 'form-inline my-2 my-lg-0 mr-auto', method: :get, local: true do |f|
   = f.search_field :body, class: 'form-control mr-sm-2', placeholder: '本文'
   = f.search_field :comment_body, class: 'form-control mr-sm-2', placeholder: 'コメント'

--- a/app/views/posts/search.html.slim
+++ b/app/views/posts/search.html.slim
@@ -1,0 +1,7 @@
+.container
+  .row
+    .col-md-8.col-12.offset-md-2
+      h2.text-center
+        | 検索結果: #{@posts.total_count}件
+      = render @posts
+      = paginate @posts

--- a/app/views/shared/_before_login_header.html.slim
+++ b/app/views/shared/_before_login_header.html.slim
@@ -3,8 +3,7 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-white
   button.navbar-toggler aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label=("Toggle navigation") data-target="#navbarTogglerDemo02" data-toggle="collapse" type="button"
     span.navbar-toggler-icon
   #navbarTogglerDemo02.collapse.navbar-collapse
-    form.form-inline.my-2.my-lg-0.mr-auto
-      input.form-control.mr-sm-2 placeholder="Search" type="search" /
+    = render 'posts/search_form', search_form: @search_form
       button.btn.btn-outline-success.my-2.my-sm-0 type="submit"  Search
     ul.navbar-nav.mt-2.mt-lg-0
       li.nav-item

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -3,9 +3,7 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-white
   button.navbar-toggler aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label=("Toggle navigation") data-target="#navbarTogglerDemo02" data-toggle="collapse" type="button"
     span.navbar-toggler-icon
   #navbarTogglerDemo02.collapse.navbar-collapse
-    form.form-inline.my-2.my-lg-0.mr-auto
-      input.form-control.mr-sm-2 placeholder="Search" type="search" /
-      button.btn.btn-outline-success.my-2.my-sm-0 type="submit"  Search
+    = render 'posts/search_form', search_form: @search_form
     ul.navbar-nav.mt-2.mt-lg-0
       li.nav-item
         / アイコンを使うのでdoでネストする

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
   resources :users, only: %i[index new create show]
   resources :posts, shallow: true do
+    # URLにpostのidはつかない
+    collection do
+      get :search
+    end
     resources :comments
   end
   # ネストさせていない。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :users, only: %i[index new create show]
   resources :posts, shallow: true do
     # URLにpostのidはつかない
+    # リソース全体(posts)に対して、アクションを追加(生成されるURL:/posts/search)
     collection do
       get :search
     end


### PR DESCRIPTION
# やったこと

- 全ての投稿を検索対象とすること（フィードに対する検索ではない）

- 検索条件としては以下の三つとする

  - 本文に検索ワードが含まれている投稿

    - こちらに関しては半角スペースでつなげることでor検索ができるようにする。e.g.「rails ruby」

  - コメントに検索ワードが含まれている投稿

  - 投稿者の名前に検索ワードが含まれている投稿

- ransackなどの検索用のGemは使わず、フォームオブジェクト、ActiveModelを使って実装すること

- 検索時のパスは/posts/searchとすること