### PR TITLE
08 ユーザーの詳細ページに投稿一覧を表示する

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -98,3 +98,23 @@ img {
 .pagination {
   justify-content: center;
 }
+
+.thumbs {
+  width: 100%;
+  position: relative;
+  display: block;
+
+  &::before {
+    content: "";
+    display: block;
+    padding-top: 100%;
+  }
+
+  img {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    object-fit: cover;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -104,6 +104,7 @@ img {
   position: relative;
   display: block;
 
+  // 疑似要素と呼ばれ、「HTMLには書かれていない要素もどきをCSSで作ることができる」
   &::before {
     content: "";
     display: block;
@@ -115,6 +116,7 @@ img {
     height: 100%;
     position: absolute;
     top: 0;
+    // 中央からトリミングしてくれる
     object-fit: cover;
   }
 }

--- a/app/views/posts/_thumbnail_post.html.slim
+++ b/app/views/posts/_thumbnail_post.html.slim
@@ -1,3 +1,3 @@
 .col-md-4.mb-3
-  = link_to post_path(post), class: 'thumbs' do
-    = image_tag post.images.first.url
+  = link_to post_path(thumbnail_post), class: 'thumbs' do
+    = image_tag thumbnail_post.images.first.url

--- a/app/views/posts/_thumbnail_post.html.slim
+++ b/app/views/posts/_thumbnail_post.html.slim
@@ -1,0 +1,3 @@
+.col-md-4.mb-3
+  = link_to post_path(post), class: 'thumbs' do
+    = image_tag post.images.first.url

--- a/app/views/posts/_thumbnail_post.html.slim
+++ b/app/views/posts/_thumbnail_post.html.slim
@@ -1,3 +1,4 @@
 .col-md-4.mb-3
   = link_to post_path(thumbnail_post), class: 'thumbs' do
+    / carrierwaveを導入しているため、urlメソッドが使える
     = image_tag thumbnail_post.images.first.url

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -14,7 +14,7 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-white
         a.nav-link href="#"
           = icon 'far', 'heart', class: 'fa-lg'
       li.nav-item
-        a.nav-link href="#"
+        = link_to user_path(current_user), class: 'nav-link' do
           = icon 'far', 'user', class: 'fa-lg'
       li.nav-item
         = link_to 'ログアウト', logout_path, class: 'nav-link', method: :delete

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,6 +1,6 @@
 .container
   .row
-    .col-md-6.offset-md-3
+    .col-md-10.offset-md-1
       .card
         .card-body
           .text-center.mb-3

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -9,3 +9,7 @@
             = @user.username
           .text-center
             = render 'follow_area', user: @user
+          hr
+            .row
+              / 部分テンプレート内のthumbnail_post変数に@user.postsの要素分の数だけ代入される
+              = render partial: 'posts/thumbnail_post', collection: @user.posts


### PR DESCRIPTION
# やったこと
- タイル表示させる

- ヘッダーのユーザーアイコンに自分のユーザー詳細ページへのリンクを設定してさせる